### PR TITLE
feat(ai): Enhance taste profile with play record descriptions

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface PlayRecord {
   total_time: number; // 总进度（秒）
   save_time: number; // 记录保存时间（时间戳）
   search_title: string; // 搜索时使用的标题
+  description?: string;
 }
 
 // 收藏数据结构


### PR DESCRIPTION
Enriches the AI taste profile generation by incorporating the `description` field from user play records.

The `generateAndCacheTasteProfile` function in `src/lib/discover_sort.ts` has been updated to:
1.  Include the `description` (synopsis) of watched and abandoned titles in the data sent to the Ollama model.
2.  Sanitize the description text to prevent special characters from breaking the prompt structure.
3.  Update the AI prompt to explicitly instruct the model to leverage the new, richer context from the descriptions for a more nuanced analysis of user preferences, especially regarding themes and plot elements.

This change aims to significantly improve the accuracy and depth of the generated AI taste profiles.