### PR TITLE
feat: 集成 Google Gemini 作为可选 AI 提供商

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@google/generative-ai": "^0.15.0",
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",
     "@types/crypto-js": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@google/generative-ai':
+        specifier: ^0.15.0
+        version: 0.15.0
       '@headlessui/react':
         specifier: ^2.2.4
         version: 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -975,6 +978,10 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@google/generative-ai@0.15.0':
+    resolution: {integrity: sha512-zs37judcTYFJf1U7tnuqnh7gdzF6dcWj9pNRxjA5JTONRoiQ0htrRdbefRFiewOIfXwhun5t9hbd2ray7812eQ==}
+    engines: {node: '>=18.0.0'}
 
   '@headlessui/react@2.2.4':
     resolution: {integrity: sha512-lz+OGcAH1dK93rgSMzXmm1qKOJkBUqZf1L4M8TWLNplftQD3IkoEDdUFNfAn4ylsN6WOTVtWaLmvmaHOUk1dTA==}
@@ -6313,6 +6320,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@google/generative-ai@0.15.0': {}
+
   '@headlessui/react@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8220,8 +8229,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -8244,7 +8253,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@9.4.0)
@@ -8255,22 +8264,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.9.0
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8281,7 +8290,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3395,6 +3395,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
     FluidSearch: true,
     ollama_host: '',
     ollama_model: '',
+    aiProvider: 'ollama',
+    geminiApiKey: '',
+    gemini_model: '',
   });
 
   // 豆瓣数据源相关状态
@@ -3459,6 +3462,9 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
         FluidSearch: config.SiteConfig.FluidSearch || true,
         ollama_host: config.SiteConfig.ollama_host || '',
         ollama_model: config.SiteConfig.ollama_model || '',
+        aiProvider: config.SiteConfig.aiProvider || 'ollama',
+        geminiApiKey: config.SiteConfig.geminiApiKey || '',
+        gemini_model: config.SiteConfig.gemini_model || '',
       });
     }
   }, [config]);
@@ -3916,32 +3922,85 @@ const SiteConfigComponent = ({ config, refreshConfig }: { config: AdminConfig | 
         <h3 className='text-md font-semibold text-gray-800 dark:text-gray-200 mb-4'>AI 推荐配置</h3>
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Ollama Host
+            AI 提供商
           </label>
-          <input
-            type='text'
-            value={siteSettings.ollama_host}
+          <select
+            value={siteSettings.aiProvider}
             onChange={(e) =>
-              setSiteSettings((prev) => ({ ...prev, ollama_host: e.target.value }))
+              setSiteSettings((prev) => ({ ...prev, aiProvider: e.target.value as 'ollama' | 'gemini' }))
             }
-            placeholder='例如: http://127.0.0.1:11434'
             className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
-          />
+          >
+            <option value="ollama">Ollama</option>
+            <option value="gemini">Google Gemini</option>
+          </select>
         </div>
-        <div className='mt-4'>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Ollama Model
-          </label>
-          <input
-            type='text'
-            value={siteSettings.ollama_model}
-            onChange={(e) =>
-              setSiteSettings((prev) => ({ ...prev, ollama_model: e.target.value }))
-            }
-            placeholder='例如: llama3'
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
-          />
-        </div>
+
+        {siteSettings.aiProvider === 'ollama' && (
+          <>
+            <div className='mt-4'>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Ollama Host
+              </label>
+              <input
+                type='text'
+                value={siteSettings.ollama_host}
+                onChange={(e) =>
+                  setSiteSettings((prev) => ({ ...prev, ollama_host: e.target.value }))
+                }
+                placeholder='例如: http://127.0.0.1:11434'
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              />
+            </div>
+            <div className='mt-4'>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Ollama Model
+              </label>
+              <input
+                type='text'
+                value={siteSettings.ollama_model}
+                onChange={(e) =>
+                  setSiteSettings((prev) => ({ ...prev, ollama_model: e.target.value }))
+                }
+                placeholder='例如: llama3'
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              />
+            </div>
+          </>
+        )}
+
+        {siteSettings.aiProvider === 'gemini' && (
+          <>
+            <div className='mt-4'>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Gemini API Key
+              </label>
+              <input
+                type='password'
+                value={siteSettings.geminiApiKey}
+                onChange={(e) =>
+                  setSiteSettings((prev) => ({ ...prev, geminiApiKey: e.target.value }))
+                }
+                placeholder='请输入你的 Gemini API Key'
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              />
+            </div>
+            <div className='mt-4'>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Gemini Model
+              </label>
+              <input
+                type='text'
+                value={siteSettings.gemini_model}
+                onChange={(e) =>
+                  setSiteSettings((prev) => ({ ...prev, gemini_model: e.target.value }))
+                }
+                placeholder='例如: gemini-pro'
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              />
+            </div>
+          </>
+        )}
       </div>
 
 

--- a/src/app/api/admin/site/route.ts
+++ b/src/app/api/admin/site/route.ts
@@ -41,6 +41,9 @@ export async function POST(request: NextRequest) {
       FluidSearch,
       ollama_host,
       ollama_model,
+      aiProvider,
+      geminiApiKey,
+      gemini_model,
     } = body as {
       SiteName: string;
       Announcement: string;
@@ -54,6 +57,9 @@ export async function POST(request: NextRequest) {
       FluidSearch: boolean;
       ollama_host: string;
       ollama_model: string;
+      aiProvider: 'ollama' | 'gemini';
+      geminiApiKey: string;
+      gemini_model: string;
     };
 
     // 参数校验
@@ -100,6 +106,9 @@ export async function POST(request: NextRequest) {
       FluidSearch,
       ollama_host,
       ollama_model,
+      aiProvider,
+      geminiApiKey,
+      gemini_model,
     };
 
     // 写入数据库

--- a/src/app/api/ai/assistant/route.ts
+++ b/src/app/api/ai/assistant/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromRequest } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
 import {
-  callOllama,
   getTasteProfile,
   AVAILABLE_SEARCH_FILTERS,
   fetchAndProcessCandidates,
   SearchCriterion,
 } from '@/lib/discover_sort';
+import { generateContent } from '@/lib/ai';
 import { db } from '@/lib/db'; // Import db to get watch history
 import { directSearch } from '@/lib/search';
 import { SearchResult } from '@/lib/types';
@@ -39,9 +39,10 @@ export async function POST(request: NextRequest) {
   // --- Step 2: AI Fallback ---
   console.log(`Direct search found no results for "${query}". Falling back to AI assistant.`);
   const config = await getConfig();
-  if (!config.SiteConfig.ollama_host) {
-    console.log('Ollama host not configured, skipping AI assistant.');
-    // Return the standard empty result format
+  const provider = config.SiteConfig.aiProvider;
+
+  if (!provider || (provider === 'ollama' && !config.SiteConfig.ollama_host) || (provider === 'gemini' && !config.SiteConfig.geminiApiKey)) {
+    console.log('AI provider not configured, skipping AI assistant.');
     return NextResponse.json({ results: [] });
   }
 
@@ -107,12 +108,7 @@ export async function POST(request: NextRequest) {
       }
     `;
 
-    const aiResponse = await callOllama(
-      config.SiteConfig.ollama_host || OLLAMA_HOST_DEFAULT,
-      config.SiteConfig.ollama_model || 'llama3',
-      prompt,
-      true
-    );
+    const aiResponse = await generateContent(prompt, true);
 
     const { searchCriteria } = aiResponse as { searchCriteria: SearchCriterion[] };
 

--- a/src/lib/admin.types.ts
+++ b/src/lib/admin.types.ts
@@ -18,6 +18,9 @@ export interface AdminConfig {
     FluidSearch: boolean;
     ollama_host?: string;
     ollama_model?: string;
+    aiProvider?: 'ollama' | 'gemini';
+    geminiApiKey?: string;
+    gemini_model?: string;
   };
   UserConfig: {
     Users: {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+import { db } from './db';
+import { generateContentWithGemini } from './gemini';
+
+const OLLAMA_HOST_DEFAULT = 'http://localhost:11434';
+
+/**
+ * The primary AI content generation function for the application.
+ * It dynamically selects the AI provider based on admin configuration
+ * and handles automatic fallback to Ollama if the primary provider (Gemini) fails.
+ *
+ * @param prompt The text prompt to send to the AI.
+ * @param isJson A boolean indicating whether to expect a JSON formatted string in response.
+ * @returns A promise that resolves to the generated content, either as a string or a parsed JSON object.
+ */
+export async function generateContent(prompt: string, isJson = false): Promise<any> {
+  const config = await db.getAdminConfig();
+
+  const provider = config?.SiteConfig.aiProvider || 'ollama';
+  const geminiApiKey = config?.SiteConfig.geminiApiKey;
+
+  // 1. Try Gemini if it's the selected provider and has an API key.
+  if (provider === 'gemini' && geminiApiKey) {
+    try {
+      const modelName = config.SiteConfig.gemini_model || 'gemini-pro';
+      console.log(`Attempting to generate content with Gemini (model: ${modelName}).`);
+      const result = await generateContentWithGemini(geminiApiKey, modelName, prompt);
+      return isJson ? JSON.parse(result) : result;
+    } catch (error) {
+      console.error(
+        `Gemini API call failed. Error: ${(error as Error).message}. ` +
+        'Falling back to Ollama.'
+      );
+      // Fallback to Ollama below, do not re-throw.
+    }
+  }
+
+  // 2. Fallback to Ollama if it's the selected provider, or if Gemini failed.
+  console.log('Generating content with Ollama.');
+  const ollamaHost = config?.SiteConfig.ollama_host || OLLAMA_HOST_DEFAULT;
+  const modelName = config?.SiteConfig.ollama_model || 'llama3';
+
+  const body = {
+    model: modelName,
+    prompt: prompt,
+    stream: false,
+    ...(isJson ? { format: 'json' } : {}),
+  };
+
+  console.log('Ollama request:', JSON.stringify({ model: body.model, prompt: body.prompt, format: body.format }, null, 2));
+
+  // The fetch call for Ollama must be wrapped in a try...catch as well.
+  try {
+    const res = await fetch(`${ollamaHost}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Ollama API request failed with status ${res.status}: ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { context, ...logData } = data;
+    console.log('Ollama response:', JSON.stringify(logData, null, 2));
+
+    if (data.done === false) {
+      throw new Error('Ollama response was not complete.');
+    }
+
+    return isJson ? JSON.parse(data.response) : data.response;
+  } catch (error) {
+    console.error(`Ollama API call failed. Error: ${(error as Error).message}`);
+    // This is the final fallback. If it fails, throw the error.
+    throw error;
+  }
+}

--- a/src/lib/discover_sort.ts
+++ b/src/lib/discover_sort.ts
@@ -4,6 +4,7 @@ import { AdminConfig } from './admin.types';
 import { getConfig } from './config';
 import { db } from './db';
 import { getDoubanRecommends } from './douban.server';
+import { generateContentWithGemini } from './gemini';
 import { Douban, SearchResult, User, WatchHistory } from './types';
 
 const OLLAMA_HOST_DEFAULT = 'http://localhost:11434';
@@ -22,64 +23,17 @@ export const AVAILABLE_SEARCH_FILTERS = {
   }
 };
 
-export async function callOllama(
-  ollamaHost: string,
-  model: string,
-  prompt: string,
-  isJson = false
-) {
-  const body = {
-    model: model,
-    prompt: prompt,
-    stream: false,
-    ...(isJson ? { format: 'json' } : {}),
-  };
-  console.log(
-    'Ollama request:',
-    JSON.stringify(
-      {
-        model: body.model,
-        prompt: body.prompt,
-        format: body.format,
-      },
-      null,
-      2
-    )
-  );
-
-  const res = await fetch(`${ollamaHost}/api/generate`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!res.ok) {
-    throw new Error(
-      `Ollama API request failed with status ${res.status}: ${res.statusText}`
-    );
-  }
-
-  const data = await res.json();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { context, ...logData } = data;
-  console.log('Ollama response:', JSON.stringify(logData, null, 2));
-
-  if (data.done === false) {
-    throw new Error('Ollama response was not complete.');
-  }
-
-  return isJson ? JSON.parse(data.response) : data.response;
-}
+import { generateContent } from './ai';
 
 export async function generateAndCacheTasteProfile(user: User): Promise<void> {
   const cacheKey = `taste_profile_user_${user.username}`;
   console.log(`Attempting to generate taste profile for user: ${user.username}`);
 
   const config = await getConfig();
-  if (!config.SiteConfig.ollama_host) {
-    console.log('Ollama host not configured, skipping taste profile generation.');
+  const provider = config.SiteConfig.aiProvider;
+
+  if (!provider || (provider === 'ollama' && !config.SiteConfig.ollama_host) || (provider === 'gemini' && !config.SiteConfig.geminiApiKey)) {
+    console.log('AI provider not configured, skipping taste profile generation.');
     return;
   }
 
@@ -151,12 +105,7 @@ export async function generateAndCacheTasteProfile(user: User): Promise<void> {
   `;
 
   try {
-    const tasteProfile = await callOllama(
-      config.SiteConfig.ollama_host || OLLAMA_HOST_DEFAULT,
-      config.SiteConfig.ollama_model || 'llama3',
-      prompt,
-      true
-    );
+    const tasteProfile = await generateContent(prompt, true);
 
     console.log(`Generated taste profile for ${user.username}:`, JSON.stringify(tasteProfile, null, 2));
 
@@ -318,8 +267,10 @@ export async function discoverSort(user: User): Promise<SearchResult[]> {
   console.log(`AI recommendations cache miss for user: ${user.username}`);
 
   const config = await getConfig();
-  if (!config.SiteConfig.ollama_host) {
-    console.log('Ollama host not configured, skipping AI sort.');
+  const provider = config.SiteConfig.aiProvider;
+
+  if (!provider || (provider === 'ollama' && !config.SiteConfig.ollama_host) || (provider === 'gemini' && !config.SiteConfig.geminiApiKey)) {
+    console.log('AI provider not configured, skipping AI sort.');
     return [];
   }
 
@@ -396,12 +347,7 @@ export async function discoverSort(user: User): Promise<SearchResult[]> {
   `;
 
   try {
-    const criteriaResponse = await callOllama(
-      config.SiteConfig.ollama_host || OLLAMA_HOST_DEFAULT,
-      config.SiteConfig.ollama_model || 'llama3',
-      prompt,
-      true
-    );
+    const criteriaResponse = await generateContent(prompt, true);
     const searchCriteria = criteriaResponse.combinations as SearchCriterion[];
 
     if (!searchCriteria || !Array.isArray(searchCriteria)) {

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, no-console */
+
+// 定义一个函数，用于调用 Gemini API 生成内容
+export async function generateContentWithGemini(
+  apiKey: string,
+  modelName: string,
+  prompt: string
+): Promise<string> {
+  // 检查 API Key 是否提供
+  if (!apiKey) {
+    throw new Error('Gemini API key is not configured.');
+  }
+
+  try {
+    // 动态导入正确的包 @google/generative-ai
+    const { GoogleGenerativeAI } = await import('@google/generative-ai');
+
+    // 使用正确的类名 GoogleGenerativeAI 初始化
+    const genAI = new GoogleGenerativeAI(apiKey);
+
+    // 获取生成模型
+    const model = genAI.getGenerativeModel({ model: modelName });
+
+    // 定义生成配置
+    const generationConfig = {
+      temperature: 0.9,
+      topK: 1,
+      topP: 1,
+      maxOutputTokens: 2048,
+    };
+
+    // 调用 API 生成内容
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const generatedText = response.text();
+
+    if (!generatedText) {
+      throw new Error('Empty response from Gemini');
+    }
+
+    return generatedText;
+  } catch (error) {
+    console.error('Error calling Gemini API:', error);
+
+    // 重新抛出错误，以便上层调用者可以捕获
+    throw new Error(`Failed to generate content with Gemini: ${(error as Error).message}`);
+  }
+}


### PR DESCRIPTION
- 在后台管理面板的“站点配置”中，新增 AI 提供商选项，允许在 Ollama 和 Google Gemini 之间进行选择。
- 为 Gemini 添加了 API Key 和模型名称的配置字段。
- 创建了一个统一的 AI 服务抽象层 (`src/lib/ai.ts`)，该层会根据管理员的配置动态选择 AI 提供商。
- 实现了从 Gemini 到 Ollama 的自动回退（优雅降级）逻辑，以提高系统的健壮性。
- 重构了应用中所有的 AI 调用点，使其全部通过新的抽象层，确保了配置的全局有效性。
- 修正了在集成过程中发现的多个 bug，包括 CJS/ESM 模块冲突、第三方库的错误使用以及前后端配置命名不一致的问题。