### PR TITLE
feat: Save favorite description and enhance AI taste profile

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1219,6 +1219,7 @@ function PlayPageClient() {
           total_episodes: detailRef.current?.episodes.length || 1,
           save_time: Date.now(),
           search_title: searchTitle,
+          description: detailRef.current?.desc,
         });
         setFavorited(true);
       }

--- a/src/lib/db.client.ts
+++ b/src/lib/db.client.ts
@@ -51,6 +51,7 @@ export interface Favorite {
   total_episodes: number;
   save_time: number;
   search_title?: string;
+  description?: string;
   origin?: 'vod' | 'live';
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,7 @@ export interface Favorite {
   cover: string;
   save_time: number; // 记录保存时间（时间戳）
   search_title: string; // 搜索时使用的标题
+  description?: string;
   origin?: 'vod' | 'live';
 }
 


### PR DESCRIPTION
This commit introduces two enhancements:

1.  When a user favorites an item, its description (synopsis) is now saved along with other metadata. This required updating the `Favorite` type on both the client and server, and modifying the `handleToggleFavorite` function in the player to pass this data.

2.  The user's list of favorites is now used as a primary data source for generating their "AI Taste Profile". In the AI prompt, favorites are explicitly marked as the strongest preference signal, improving the accuracy and personalization of the generated profile.