### PR TITLE
fix(api): improve ad-free M3U8 filtering to remove ad blocks completely

### DIFF
--- a/src/app/api/proxy/ad-free/route.ts
+++ b/src/app/api/proxy/ad-free/route.ts
@@ -42,12 +42,19 @@ function filterAdsFromM3U8(m3u8Content: string, baseUrl: string, req: Request, a
   // 按行分割M3U8内容
   const lines = m3u8Content.split('\n');
   const filteredLines = [];
+  let inAdBlock = false;
 
   for (let i = 0; i < lines.length; i++) {
     let line = lines[i].trim();
 
     // 过滤广告标识
     if (line.includes('#EXT-X-DISCONTINUITY')) {
+      inAdBlock = !inAdBlock;
+      continue;
+    }
+
+    // 处于广告区块内，直接抛弃所有的TS切片、EXTINF等信息
+    if (inAdBlock) {
       continue;
     }
 


### PR DESCRIPTION
- Introduce `inAdBlock` state in `filterAdsFromM3U8` function.
- Drop all lines (including `.ts` slices and `#EXTINF`) wrapped between `#EXT-X-DISCONTINUITY` tags.
- Fix issue where decoder hangs trying to decode ad segments without the discontinuity instruction.